### PR TITLE
Add test app scripts and settings.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 test/test-bundle.js
+test/end-to-end-testapp/compilation.js

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "scripts": {
     "testKarma": "node test/boilerplate/test-karma.js",
-    "watch": "watchify ./node_modules/@mparticle/web-kit-wrapper/index.js -v -o build/$KIT-Kit.js"
+    "watch": "watchify ./node_modules/@mparticle/web-kit-wrapper/index.js -v -o build/$KIT-Kit.js",
+    "testEndToEnd": "browserify node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/index.js -v -o test/end-to-end-testapp/build/compilation.js && open http://localhost:8082/node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/index.html && node node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/server"
   },
   "devDependencies": {
     "@mparticle/web-kit-wrapper": "^1.0.0-rc4",
@@ -18,9 +19,9 @@
     "karma-junit-reporter": "^1.2.0",
     "karma-mocha": "^1.3.0",
     "karma-safari-launcher": "^1.0.0",
-    "shelljs": "^0.8.3",
+    "shelljs": "0.8.3",
     "mparticle-sdk-javascript": "github:mparticle/mparticle-sdk-javascript",
-    "should": "^7.1.0",
-    "watchify": "^3.9.0"
+    "should": "13.2.3",
+    "watchify": "^3.11.0"
   }
 }

--- a/test/end-to-end-testapp/settings.js
+++ b/test/end-to-end-testapp/settings.js
@@ -1,0 +1,10 @@
+var SDKsettings = {
+    apiKey: 'testAPIKey'
+    /* fill in SDKsettings with any particular settings or options your sdk requires in order to
+    initialize, this may be apiKey, projectId, primaryCustomerType, etc. These are passed
+    into the integration-builder/initialization.js file as the
+    */
+};
+
+// Do not edit below:
+module.exports = SDKsettings;


### PR DESCRIPTION
For the integration example, I am adding a script so they can just run `npm run testEndToEnd` which will compile their integration code, forwarder settings, and fire up a server