### PR TITLE
Bugfix - do not set common to empty object in user-attribute-handler.js

### DIFF
--- a/src/user-attribute-handler.js
+++ b/src/user-attribute-handler.js
@@ -8,7 +8,7 @@ For any additional methods, see http://docs.mparticle.com/developers/sdk/javascr
 */
 
 function UserAttributeHandler(common) {
-    this.common = common = {};
+    this.common = common || {};
 }
 UserAttributeHandler.prototype.onRemoveUserAttribute = function(
     key,


### PR DESCRIPTION
UserAttributeHandler's common would always be set to `{}`. Changing `=` to `||`