### PR TITLE
Update version to 1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "testKarma": "node test/boilerplate/test-karma.js",
     "build": "ENVIRONMENT=production rollup --config rollup.config.js",
     "watch": "ENVIRONMENT=production rollup --config rollup.config.js -w",
-    "testEndToEnd": "ENVIRONMENT=endToEndTest rollup --config rollup.config.js && open http://localhost:8082/node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/index.html && node node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/server"
+    "testEndToEnd": "ENVIRONMENT=testEndToEnd rollup --config rollup.config.js && open http://localhost:8082/node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/index.html && node node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/server"
   },
   "devDependencies": {
     "@mparticle/web-kit-wrapper": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "integration-nameOfYourIntegration",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "scripts": {
     "testKarma": "node test/boilerplate/test-karma.js",
     "build": "ENVIRONMENT=production rollup --config rollup.config.js",
@@ -8,7 +8,7 @@
     "testEndToEnd": "ENVIRONMENT=testEndToEnd rollup --config rollup.config.js && open http://localhost:8082/node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/index.html && node node_modules/@mparticle/web-kit-wrapper/end-to-end-testapp/server"
   },
   "devDependencies": {
-    "@mparticle/web-kit-wrapper": "^1.0.3",
+    "@mparticle/web-kit-wrapper": "^1.0.5",
     "mocha": "^5.2.0",
     "chai": "^4.2.0",
     "karma": "^3.1.1",
@@ -28,6 +28,6 @@
     "watchify": "^3.11.0"
   },
   "dependencies": {
-    "@mparticle/web-sdk": "^2.11.3"
+    "@mparticle/web-sdk": "^2.12.2"
   }
 }

--- a/src/initialization.js
+++ b/src/initialization.js
@@ -8,7 +8,7 @@ var initialization = {
     userIdentities example: { 1: 'customerId', 2: 'facebookId', 7: 'emailid@email.com' }
     additional identityTypes can be found at https://github.com/mParticle/mparticle-sdk-javascript/blob/master-v2/src/types.js#L88-L101
 */
-    initForwarder: function(forwarderSettings, testMode, userAttributes, userIdentities, processEvent, eventQueue, isInitialized) {
+    initForwarder: function(forwarderSettings, testMode, userAttributes, userIdentities, processEvent, eventQueue, isInitialized, common, appVersion, appName, customFlags, clientId) {
         /* `forwarderSettings` contains your SDK specific settings such as apiKey that your customer needs in order to initialize your SDK properly */
 
         if (!testMode) {

--- a/src/user-attribute-handler.js
+++ b/src/user-attribute-handler.js
@@ -8,7 +8,7 @@ For any additional methods, see http://docs.mparticle.com/developers/sdk/javascr
 */
 
 function UserAttributeHandler(common) {
-    this.common = common = {};
+    this.common = common || {};
 }
 UserAttributeHandler.prototype.onRemoveUserAttribute = function(
     key,


### PR DESCRIPTION
This PR consists of 3 bugfixes:
* previously user-attribute-handler was always setting `this.common` to an empty object, it should only do so if common doesn't exist
* change the ENVIRONMENT variable from `endToEndTest` to `testEndToEnd`
* update the function signature of initForwarder to include additional arguments from when integration-wrapper was [updated](https://github.com/mparticle-integrations/mparticle-javascript-web-kit-wrapper/commit/d33d7f0a292bc76ef076439743ec25da71e2c7ff) to 1.0.4