### PR TITLE
fix: integration builder and npm publishing fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Detailed instructions on how to implement your own integration with the mParticl
 
 1. Fork this repo and `cd` into it locally on your computer.
 2. Run `npm install` to install dependencies.
-3. Run `KIT=YOURKITNAME npm run watch` to watch files in the `src/` folder, and automatically build your kit to `build/YOURKITNAME-Kit.js`. Your kit will continuously build as your save your edits.
+3. Run `KIT=YOURKITNAME npm run watch` to watch files in the `src/` folder, and automatically build your kit to `dist/YOURKITNAME-Kit.js`. Your kit will continuously build as your save your edits.
 4. Following examples such as [Optimizely](https://github.com/mparticle-integrations/mparticle-javascript-integration-optimizely), edit files in `src/`.
 5. As you map mParticle's methods to your own in `src/`, stub your SDK methods and create tests in `test/tests.js`.
 6. Submit a pull request to this repo. A developer from mParticle will review it and once complete, we will help provide you with a repo for your integration.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Detailed instructions on how to implement your own integration with the mParticl
 
 1. Fork this repo and `cd` into it locally on your computer.
 2. Run `npm install` to install dependencies.
-3. Run `KIT=YOURKITNAME npm run watch` to watch files in the `src/` folder, and automatically build your kit to `dist/YOURKITNAME-Kit.js`. Your kit will continuously build as your save your edits.
+3. Run `KIT=YOURKITNAME npm run watch` to watch files in the `src/` folder, and automatically build your kit to `dist/YOURKITNAME-Kit.iife.js`. Your kit will continuously build as your save your edits.
 4. Following examples such as [Optimizely](https://github.com/mparticle-integrations/mparticle-javascript-integration-optimizely), edit files in `src/`.
 5. As you map mParticle's methods to your own in `src/`, stub your SDK methods and create tests in `test/tests.js`.
 6. Submit a pull request to this repo. A developer from mParticle will review it and once complete, we will help provide you with a repo for your integration.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "watchify": "^3.11.0"
   },
   "dependencies": {
-    "@mparticle/web-sdk": "^2.12.2"
+    "@mparticle/web-sdk": "^2.20.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "watchify": "^3.11.0"
   },
   "dependencies": {
-    "@mparticle/web-sdk": "^2.20.2"
+    "@mparticle/web-sdk": "^2.20.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "integration-nameOfYourIntegration",
   "version": "1.0.3",
+  "main": "dist/XYZ-Kit.common.js",
+  "files": [
+    "dist/XYZ-Kit.common.js"
+  ],
   "scripts": {
     "testKarma": "node test/boilerplate/test-karma.js",
     "build": "ENVIRONMENT=production rollup --config rollup.config.js",

--- a/test/index.html
+++ b/test/index.html
@@ -10,7 +10,7 @@
     <script src="../node_modules/mocha/mocha.js"></script>
     <script src="../node_modules/should/should.js"></script>
     <script src="./boilerplate/mockhttprequest.js"></script>
-    <script src="../node_modules/mparticle-sdk-javascript/mparticle.js"></script>
+    <script src="../node_modules/mparticle-web-sdk/dist/mparticle.js"></script>
 
     <script>
         var self = mParticle;

--- a/test/index.html
+++ b/test/index.html
@@ -11,7 +11,6 @@
     <script src="../node_modules/should/should.js"></script>
     <script src="./boilerplate/mockhttprequest.js"></script>
     <script src="../node_modules/mparticle-sdk-javascript/mparticle.js"></script>
-    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@mparticle/web-sdk/dist/mparticle.js"></script>
 
     <script>
         var self = mParticle;

--- a/test/index.html
+++ b/test/index.html
@@ -21,7 +21,7 @@
 
     </script>
     <!-- change name of XYZ-Kit below to the name of your built kit-->
-    <script src="../dist/XYZ-Kit.js"></script>
+    <script src="../dist/XYZ-Kit.iife.js"></script>
 
     <script>mocha.setup('bdd')</script>
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -164,6 +164,8 @@ describe('XYZ Forwarder', function () {
             Identity: 'facebook',
             Type: IdentityType.Facebook
         }];
+
+        // The third argument here is a boolean to indicate that the integration is in test mode to avoid loading any third party scripts. Do not change this value.
         mParticle.forwarder.init(sdkSettings, reportService.cb, true, null, userAttributes, userIdentities);
     });
 


### PR DESCRIPTION
## Instructions
 1. PR target branch should be against `development`
 2. PR title name should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-title-check.yml
 3. PR branch prefix should follow this format: https://github.com/mParticle/mparticle-workflows/blob/main/.github/workflows/pr-branch-check-name.yml

 ## Summary
- Update mP web SDK version to 2.20.2
- Remove CDN dependency so web SDK is pulled from NPM
- Use iife file in testing
- include "main" and "files" fields for publishing to NPM

 ## Reference Issue (For mParticle employees only.  Ignore if you are an outside contributor)
 - Closes https://go.mparticle.com/work/SQDSDKS-4390
